### PR TITLE
Add deploy token for API cache busting

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -4,6 +4,7 @@
   <title>Databyss Admin</title>
   <link id="favicon" rel="shortcut icon" href="/favicon.png" sizes="16x16 32x32" type="image/png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="deploy-token" content="{DEPLOY_TOKEN}" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <title>{META_TITLE}</title>
   <meta name="description" content="{META_DESCRIPTION}" data-react-helmet="true">
   <meta name="keywords" content="{META_KEYWORDS}" data-react-helmet="true">
+  <meta name="deploy-token" content="{DEPLOY_TOKEN}" />
   <link rel="stylesheet" type="text/css" href="/fonts.css"/>
   <link id="favicon" rel="shortcut icon" href="/favicon.png" sizes="16x16 32x32" type="image/png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />

--- a/src/lib/apiCacheBust.js
+++ b/src/lib/apiCacheBust.js
@@ -1,0 +1,25 @@
+const DEPLOY_TOKEN_META_NAME = 'deploy-token'
+
+export const getDeployToken = () => {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const meta = document.querySelector(
+    `meta[name="${DEPLOY_TOKEN_META_NAME}"]`
+  )
+
+  return meta && meta.content ? meta.content : null
+}
+
+export const withDeployToken = url => {
+  const deployToken = getDeployToken()
+
+  if (!deployToken) {
+    return url
+  }
+
+  const separator = url.includes('?') ? '&' : '?'
+
+  return `${url}${separator}deployToken=${encodeURIComponent(deployToken)}`
+}

--- a/src/redux/app/actions.js
+++ b/src/redux/app/actions.js
@@ -5,6 +5,7 @@ import {
   motifDictFromList,
   authorDictFromList,
 } from '../../lib/indexers'
+import { withDeployToken } from '../../lib/apiCacheBust'
 
 const { API_URL } = process.env
 const { DEFAULT_AUTHOR } = process.env
@@ -18,7 +19,7 @@ export default {
           sid,
         },
       })
-      const entries = (await axios.get(`${API_URL}/sources/${sid}`)).data
+      const entries = (await axios.get(withDeployToken(`${API_URL}/sources/${sid}`))).data
       return dispatch({
         type: 'RECEIVE_SOURCE_ENTRIES',
         payload: {
@@ -43,9 +44,11 @@ export default {
         csid = showAll ? '_all' : ''
       }
       const motif = (await axios.get(
-        [API_URL, 'motifs', mid, ...(csid ? [csid] : [])]
-          .join('/')
-          .concat(`?author=${author}`)
+        withDeployToken(
+          [API_URL, 'motifs', mid, ...(csid ? [csid] : [])]
+            .join('/')
+            .concat(`?author=${author}`)
+        )
       )).data
       return dispatch({
         type: 'RECEIVE_MOTIF',
@@ -64,7 +67,7 @@ export default {
       dispatch({
         type: 'FETCH_BIBLIO',
       })
-      const sources = (await axios.get(`${API_URL}/sources`)).data
+      const sources = (await axios.get(withDeployToken(`${API_URL}/sources`))).data
       const sourceList = sourceListFromSources(sources)
       const biblio = biblioFromSources(sources)
 
@@ -82,7 +85,7 @@ export default {
       dispatch({
         type: 'FETCH_MOTIFS',
       })
-      const motifList = (await axios.get(`${API_URL}/motifs`)).data
+      const motifList = (await axios.get(withDeployToken(`${API_URL}/motifs`))).data
       const motifDict = motifDictFromList(motifList)
 
       return dispatch({
@@ -99,7 +102,7 @@ export default {
       dispatch({
         type: 'FETCH_AUTHORS',
       })
-      const authorList = (await axios.get(`${API_URL}/authors`)).data.sort(
+      const authorList = (await axios.get(withDeployToken(`${API_URL}/authors`))).data.sort(
         function(a, b) {
           return a.lastName
             .toLowerCase()
@@ -126,7 +129,7 @@ export default {
         },
       })
       const content = (await axios.get(
-        `${API_URL}/pages/${path.replace(/\//g, '%2f')}`
+        withDeployToken(`${API_URL}/pages/${path.replace(/\//g, '%2f')}`)
       )).data
 
       return dispatch({
@@ -147,7 +150,7 @@ export default {
         },
       })
       const menu = (await axios.get(
-        `${API_URL}/menus/${path.replace(/\//g, '%2f')}`
+        withDeployToken(`${API_URL}/menus/${path.replace(/\//g, '%2f')}`)
       )).data
 
       return dispatch({
@@ -164,7 +167,7 @@ export default {
       dispatch({
         type: 'FETCH_CONFIG',
       })
-      const config = (await axios.get(`${API_URL}/config`)).data
+      const config = (await axios.get(withDeployToken(`${API_URL}/config`))).data
 
       return dispatch({
         type: 'RECEIVE_CONFIG',

--- a/src/redux/search/actions.js
+++ b/src/redux/search/actions.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { withDeployToken } from '../../lib/apiCacheBust'
 
 let queryIdx = 0
 
@@ -15,7 +16,7 @@ export default {
           author,
         },
       })
-      const results = await axios.get(`${API_URL}/search`, {
+      const results = await axios.get(withDeployToken(`${API_URL}/search`), {
         params: {
           query: query || getState().search.query,
           groupBy: 'source',
@@ -41,7 +42,7 @@ export default {
       })
       const asyncDispatch = list => {
         const promises = list.map(async a => {
-          const results = await axios.get(`${API_URL}/search`, {
+          const results = await axios.get(withDeployToken(`${API_URL}/search`), {
             params: {
               query: query || getState().search.query,
               groupBy: 'source',
@@ -75,7 +76,7 @@ export default {
         type: 'SET_QUERY',
         payload: { query, id: queryIdx, author: DEFAULT_AUTHOR },
       })
-      const results = await axios.get(`${API_URL}/search`, {
+      const results = await axios.get(withDeployToken(`${API_URL}/search`), {
         params: { query, id: queryIdx, author: DEFAULT_AUTHOR },
       })
       if (results.data.id < queryIdx) {

--- a/src/scss/mobile/front.scss
+++ b/src/scss/mobile/front.scss
@@ -36,7 +36,7 @@
       align-items: center;
       width: 65%;
       transition: height 200ms ease-in-out;
-      min-height: 50vh;
+      min-height: 65vh;
     }
 
     &.withMotifs .head {
@@ -126,13 +126,12 @@
       height: auto;
     }
 
-    .title {
+    h1.title {
       font-size: 3em;
       line-height: 1em;
-      margin-bottom: 0.3em;
       font-family: 'BaskervilleLT-RegularOldFace', serif;
       letter-spacing: -0.05em;
-      white-space: nowrap;
+      margin-bottom: 0.8em;
     }
 
     .toggles {
@@ -172,6 +171,12 @@
       }
       a:hover {
         color: rgba(255, 255, 255, 0.65);
+      }
+
+      h2 {
+        font-size: 1.2em;
+        line-height: 1.1em;
+        font-weight: normal;
       }
     }
   }

--- a/src/scss/tablet/front.scss
+++ b/src/scss/tablet/front.scss
@@ -36,7 +36,8 @@
       align-items: center;
       width: 100%;
       transition: height 200ms ease-in-out;
-      min-height: 50vh;
+      min-height: 65vh;
+      margin-bottom: 3em;
     }
 
     &.withMotifs .head {
@@ -138,12 +139,12 @@
       }
     }
 
-    .title {
+    h1.title {
       font-size: 3em;
       line-height: 1em;
-      margin-bottom: 0.3em;
       font-family: 'BaskervilleLT-RegularOldFace', serif;
       letter-spacing: -0.05em;
+      margin-bottom: 0.8em;
     }
 
     p {
@@ -164,6 +165,12 @@
       }
       a:hover {
         color: rgba(255, 255, 255, 0.65);
+      }
+
+      h2 {
+        font-size: 1.2em;
+        line-height: 1.1em;
+        font-weight: normal;
       }
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,13 @@ import { renderMetaTemplate } from './lib/template';
 dotenv.config();
 
 const app = express();
+const deployToken =
+  process.env.DEPLOY_TOKEN ||
+  process.env.HEROKU_SLUG_COMMIT ||
+  process.env.GITHUB_SHA ||
+  process.env.RENDER_GIT_COMMIT ||
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  String(Date.now());
 
 app.set('port', process.env.PORT || 8080);
 app.set('host', '0.0.0.0');
@@ -53,6 +60,7 @@ async function getClientApp(req, res) {
       requestPath: req.path,
       extraDict: {
         PRODUCTION: (process.env.NODE_ENV === 'production').toString(),
+        DEPLOY_TOKEN: deployToken,
       },
     });
     res.set('Cache-Control', 'no-cache');


### PR DESCRIPTION
Introduces a deploy token mechanism to bust API response caches on new deployments. The token is derived from common CI/CD environment variables (DEPLOY_TOKEN, HEROKU_SLUG_COMMIT, GITHUB_SHA, etc.) or falls back to a timestamp. It's injected into HTML via a meta tag and appended as a query param to all API requests. Also includes minor front-end layout tweaks for mobile/tablet.